### PR TITLE
Fix locales dir assert fail gh actions

### DIFF
--- a/i18n/helpers.go
+++ b/i18n/helpers.go
@@ -28,7 +28,7 @@ func getPwdDirPath() (string, error) {
 	expectedSuffix := os.Getenv("APPROOTDIR")
 
 	// Assume that we can reach app root dir by climbing FS heirarchy
-	pattern := fmt.Sprintf(`^(.*?)(%s)`, regexp.QuoteMeta(expectedSuffix))
+	pattern := fmt.Sprintf(`^(.*)(%s)`, regexp.QuoteMeta(expectedSuffix))
 
 	re := regexp.MustCompile(pattern)
 	matches := re.FindStringSubmatch(rootPath)

--- a/i18n/helpers.go
+++ b/i18n/helpers.go
@@ -27,8 +27,13 @@ func getPwdDirPath() (string, error) {
 
 	expectedSuffix := os.Getenv("APPROOTDIR")
 
+	// Check if APPROOTDIR is not set
+	if expectedSuffix == "" {
+		return "", fmt.Errorf("APPROOTDIR is not set")
+	}
+
 	// Assume that we can reach app root dir by climbing FS heirarchy
-	pattern := fmt.Sprintf(`^(.*)(%s)`, regexp.QuoteMeta(expectedSuffix))
+	pattern := fmt.Sprintf(`^(.*)(?:%s)`, regexp.QuoteMeta(expectedSuffix))
 
 	re := regexp.MustCompile(pattern)
 	matches := re.FindStringSubmatch(rootPath)


### PR DESCRIPTION
This pr tries to solve issue #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved path resolution when the application’s root name appears multiple times in the current working directory, preventing incorrect directory detection.
  - Increased reliability when launching from nested or duplicated paths, ensuring consistent access to required resources.
  - Reduces sporadic startup issues caused by ambiguous path matching, leading to smoother initialization across varied environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->